### PR TITLE
Dont include parens unless needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,16 @@ print(file_result)
 text_result = async2rewrite.from_text('async def on_command_error(ctx, error): pass')
 print(text_result)
 
-result_without_parens = async2rewrite.from_file('file/path', remove_parens=True)
+result_without_parens = async2rewrite.from_file('file/path')
 print(result_without_parens)
 
 stats = async2rewrite.from_file('file/path', stats=True)
 print(stats) # stats=True makes from_x return a Counter.
 ```
 
-Note that the `remove_parens` kwarg can cause issues, and that it will not be perfect.
+in this fork astunparse has been edited to not insert parens in most places they are not needed. for example:
+
+```py
+>>> async2rewrite.from_text("async def test(): a = await (await (await b.c).d)[await a.b]")
+"async def test(): a = await (await (await b.c).d)[await a.b]"
+```

--- a/async2rewrite/main.py
+++ b/async2rewrite/main.py
@@ -7,14 +7,14 @@ from .transformers import *
 
 def get_result(code, **kwargs):
 
-    remove_parens = kwargs.pop('remove_parens', False)
     stats = kwargs.pop('stats', False)
     include_ast = kwargs.pop('include_ast', False)
 
     def snowflake_repl(match):
         return str(int(match.group(1)))
 
-    code = re.sub("""['\"](\d{17,18,19})['\"]""", snowflake_repl, code)  # str snowflakes to int snowflakes
+    code = re.sub(r"""['\"](\d{17,18,19})['\"]""", snowflake_repl,
+                  code)  # str snowflakes to int snowflakes
 
     expr_ast = ast.parse(code)
 
@@ -25,21 +25,15 @@ def get_result(code, **kwargs):
 
     unparsed = astunparse.unparse(new_ast)
 
-    unparsed = unparsed.replace('ctx.message.guild', 'ctx.guild').replace('ctx.message.author', 'ctx.author')
+    unparsed = unparsed.replace('ctx.message.guild', 'ctx.guild').replace(
+        'ctx.message.author', 'ctx.author')
     unparsed = unparsed.replace('ctx.message.channel', 'ctx.channel')
 
     final_ast = ast.parse(unparsed)
 
-    if remove_parens:
-        def parens_repl(match):
-            return match.group(1)
-
-        unparsed = re.sub("""(?<=\s)\((.+)\)(?=[\s:])""", parens_repl, unparsed) # this can cause some issues
-
     if include_ast:
         return unparsed, final_ast
-    else:
-        return unparsed
+    return unparsed
 
 
 def from_file(file_path, **kwargs):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/nitros12/astunparse
+-e git+https://github.com/nitros12/astunparse

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-py-backwards-astunparse>=1.5.0.post3
+git+https://github.com/nitros12/astunparse

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     author='Tyler Gibbs',
     author_email='gibbstyler7@gmail.com',
     url='https://github.com/TheTrain2000/async2rewrite',
-    # download_url='https://github.com/TheTrain2000/async2rewrite/archive/{}.tar.gz'.format(version),
+    download_url='https://github.com/TheTrain2000/async2rewrite/archive/{}.tar.gz'.format(version),
     keywords=['discord', 'discordpy', 'ast'],
     classifiers=[],
     install_requires=['https://github.com/nitros12/astunparse']

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 import os
-
 from distutils.core import setup
 
 # Thanks Laura
@@ -17,18 +16,19 @@ def extract_version(module='async2rewrite'):
                 break
     return version
 
+
 version = extract_version()
 
 setup(
-  name='async2rewrite',
-  packages=['async2rewrite'],
-  version=version,
-  description='Convert discord.py code using abstract syntax trees.',
-  author='Tyler Gibbs',
-  author_email='gibbstyler7@gmail.com',
-  url='https://github.com/TheTrain2000/async2rewrite',
-  download_url='https://github.com/TheTrain2000/async2rewrite/archive/{}.tar.gz'.format(version),
-  keywords=['discord', 'discordpy', 'ast'],
-  classifiers=[],
-  install_requires=['py-backwards-astunparse>=1.5.0.post3']
+    name='async2rewrite',
+    packages=['async2rewrite'],
+    version=version,
+    description='Convert discord.py code using abstract syntax trees.',
+    author='Tyler Gibbs',
+    author_email='gibbstyler7@gmail.com',
+    url='https://github.com/TheTrain2000/async2rewrite',
+    # download_url='https://github.com/TheTrain2000/async2rewrite/archive/{}.tar.gz'.format(version),
+    keywords=['discord', 'discordpy', 'ast'],
+    classifiers=[],
+    install_requires=['https://github.com/nitros12/astunparse']
 )


### PR DESCRIPTION
Remove `remove_parens` param, use fork of astunparse that does not include parens in most unneded places